### PR TITLE
Fixed a Typo

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -985,12 +985,7 @@ Technical report, 2022.
 
 <li>
     <b>Open Problems in (Hyper)Graph Decomposition</b>.
-    Deepak Ajwani, Rob H. Bisseling, Katrin Casel, Ümit V. Çatalyürek, Cédric Chevalier,
-Florian Chudigiewitsch and Marcelo Fonseca Faraj, Michael Fellows, Lars Gottesbüren,
-Tobias Heuer, George Karypis, Kamer Kaya, Jakub Lacki, Johannes Langguth, Xiaoye
-Sherry Li, Ruben Mayer, Johannes Meintrup, Yosuke Mizutani, François Pellegrini, Fa-
-brizio Petrini, Frances Rosamond, Ilya Safro, Sebastian Schlag, Christian Schulz, Rooha-
-ni Sharma, Darren Strash, Blair D. Sullivan, Bora Uçar and Albert-Jan Yzelman.  Technical report, Various Affiliations, 2023.
+    Deepak Ajwani, Rob H. Bisseling, Katrin Casel, Ümit V. Çatalyürek, Cédric Chevalier, Florian Chudigiewitsch and Marcelo Fonseca Faraj, Michael Fellows, Lars Gottesbüren, Tobias Heuer, George Karypis, Kamer Kaya, Jakub Lacki, Johannes Langguth, Xiaoye Sherry Li, Ruben Mayer, Johannes Meintrup, Yosuke Mizutani, François Pellegrini, Fabrizio Petrini, Frances Rosamond, Ilya Safro, Sebastian Schlag, Christian Schulz, Roohani Sharma, Darren Strash, Blair D. Sullivan, Bora Uçar and Albert-Jan Yzelman. Technical report, Various Affiliations, 2023.
     <a href="https://arxiv.org/pdf/2310.11812.pdf">PDF</a>
 </li>
 

--- a/publications.html
+++ b/publications.html
@@ -100,12 +100,7 @@ Ernestine Großmann, Tobias Heuer, Christian Schulz, Darren Strash.
 
 <li>
     <b>Recent Trends in Graph Decomposition</b>.
-    Deepak Ajwani, Rob H. Bisseling, Katrin Casel, Ümit V. Çatalyürek, Cédric Chevalier,
-Florian Chudigiewitsch and Marcelo Fonseca Faraj, Michael Fellows, Lars Gottesbüren,
-Tobias Heuer, George Karypis, Kamer Kaya, Jakub Lacki, Johannes Langguth, Xiaoye
-Sherry Li, Ruben Mayer, Johannes Meintrup, Yosuke Mizutani, François Pellegrini, Fa-
-brizio Petrini, Frances Rosamond, Ilya Safro, Sebastian Schlag, Christian Schulz, Rooha-
-ni Sharma, Darren Strash, Blair D. Sullivan, Bora Uçar and Albert-Jan Yzelman. To Appear, 2023.
+    Deepak Ajwani, Rob H. Bisseling, Katrin Casel, Ümit V. Çatalyürek, Cédric Chevalier, Florian Chudigiewitsch and Marcelo Fonseca Faraj, Michael Fellows, Lars Gottesbüren, Tobias Heuer, George Karypis, Kamer Kaya, Jakub Lacki, Johannes Langguth, Xiaoye Sherry Li, Ruben Mayer, Johannes Meintrup, Yosuke Mizutani, François Pellegrini, Fabrizio Petrini, Frances Rosamond, Ilya Safro, Sebastian Schlag, Christian Schulz, Roohani Sharma, Darren Strash, Blair D. Sullivan, Bora Uçar and Albert-Jan Yzelman. To Appear, 2023.
 </li>
 
 


### PR DESCRIPTION
Names in the latest "Recent Trends in Graph Decomposition" had small typos, for example "Fa- brizio Petrini," or "Rooha- ni Sharma". Rewrote them into one line and removed these typos.